### PR TITLE
OpenAPI 3.0の導入

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     volumes_from:
       - db-storage
   app:
+    tty: true
+    stdin_open: true
     build:
       context: .
       dockerfile: dockerfiles/app/Dockerfile
@@ -18,6 +20,10 @@ services:
     volumes:
       - .:/yakyu
     ports:
-      - "3000:3000"
+      - 3000:3000
     depends_on:
       - db
+  swagger-editor:
+    image: swaggerapi/swagger-editor
+    ports:
+      - 80:8080

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -28,13 +28,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PitcherCountTypes'
+                type: array
+                items:
+                  $ref: '#/components/schemas/PitcherCountType'
 components:
   schemas:
-    PitcherCountTypes:
-      type: array
-      items:
-        $ref: '#/components/schemas/PitcherCountType'
     PitcherCountType:
       required:
         - pitch_type

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: yakyu API
+  license:
+    name: MIT
+paths:
+  /pitch_type_count:
+    get:
+      summary: pitch counts by pitch types
+      operationId: pitchCountsByPitchTypes
+      parameters:
+        - name: pitcher_first_name
+          in: query
+          description: Pitcher first name ex. Masahiro
+          required: false
+          schema:
+            type: string
+        - name: pitcher_last_name
+          in: query
+          description: Pitcher last name ex. Tanaka
+          required: false
+          schema:
+            type: string
+      responses:
+        200:
+          description: valid response which includes counts by pitch type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PitcherCountTypes'
+components:
+  schemas:
+    PitcherCountTypes:
+      type: array
+      items:
+        $ref: '#/components/schemas/PitcherCountType'
+    PitcherCountType:
+      required:
+        - pitch_type
+        - count
+      properties:
+        pitch_type:
+          type: string
+        count:
+          type: integer
+          format: int64


### PR DESCRIPTION
- swagger-editor用のdocker image追加
- OpenAPI 3.0のスキーマ定義追加

参考

A Sample OpenAPI 3.0 File To Get Started
https://apievangelist.com/2017/09/13/a-sample-openapi-30-file-to-get-started/

OpenAPI-Specification/api-with-examples.yaml at master · OAI/OpenAPI-Specification
https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/api-with-examples.yaml

